### PR TITLE
Fixes issue in `v-change-user-php-cli` example

### DIFF
--- a/cli_commands/commands.rst
+++ b/cli_commands/commands.rst
@@ -2341,7 +2341,7 @@ v-change-user-php-cli
 
 .. code-block:: bash
    
-  v-change-user-php-cli user php7.4
+  v-change-user-php-cli user 7.4
    
 
 add line to .bash_aliases to set default php command line version when multi-php is enabled.


### PR DESCRIPTION
This script requires the PHP version as the second argument e.g. `7.4`, not `php7.4`.

PR for example in the control panel: [#1914](https://github.com/hestiacp/hestiacp/pull/1914)