### PR TITLE
Add warning to add IP to whitelist

### DIFF
--- a/admin_docs/dns.rst
+++ b/admin_docs/dns.rst
@@ -8,6 +8,8 @@ How to setup a DNS Cluster
 
 If you are looking for the options to minimize DNS-related downtime or the way to manage dns across all server you have, you might consider to set up dns cluster.
 
+**NOTE**: Ensure that your master server's IP is whitelisted in *Configure Server* -> *Security* -> *Allowed IP addresses for API*, otherwise you will get an error when adding the slave server to the cluster.
+
 #. Create user **dns-cluster** on a server which will be used as dns slave
 #. Run following command on a master
 


### PR DESCRIPTION
The documentation doesn't specify this at first, so some admins might get lost.

The DNS Cluster functionality uses the API, which is by default on a whitelist-only setup. To do this, the administrator must first whitelist their server's IP in the **Allowed IP addresses for API** setting in the System Configuration module.