### PR TITLE
Update dns.rst

### DIFF
--- a/admin_docs/dns.rst
+++ b/admin_docs/dns.rst
@@ -44,15 +44,19 @@ Yes you can just supply the user variable behind the command.
 
 .. code-block:: bash
 
-    v-add-remote-dns-host slave.yourhost.com 8083 admin p4sw0rd '' useraccount
+    v-add-remote-dns-host slave.yourhost.com 8083 admin p4sw0rd api useraccount
 
 Or 
 
 .. code-block:: bash   
 
-    v-add-remote-dns-host slave.yourhost.com 8083 api_key '' '' useraccount
+    v-add-remote-dns-host slave.yourhost.com 8083 api_key '' api useraccount
 
 With the new API system you can also replace api_key with access_key:secret_key 
+
+.. code-block:: bash   
+
+    v-add-remote-dns-host slave.yourhost.com 8083 access_key:secret_key '' api useraccount
 
 Please note that currently only the user dns-user is exempted from syncing to other servers. If you have a DNS cluster with multiple master slaves you might run in issues.
     


### PR DESCRIPTION
Prevent error:
`Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
Error:  type is invalid`

Used `type=${5-api}` does not work correctly with '' as parameter.